### PR TITLE
Changed instances of event.touches to event.targetTouches

### DIFF
--- a/src/propeller.js
+++ b/src/propeller.js
@@ -172,10 +172,10 @@
             event.stopPropagation();
             event.preventDefault();
 
-            if (event.touches !== undefined && event.touches[0] !== undefined) {
+            if (event.targetTouches !== undefined && event.targetTouches[0] !== undefined) {
                 this.lastMouseEvent = {
-                    pageX: event.touches[0].pageX,
-                    pageY: event.touches[0].pageY
+                    pageX: event.targetTouches[0].pageX,
+                    pageY: event.targetTouches[0].pageY
                 }
             } else {
                 this.lastMouseEvent = {
@@ -205,7 +205,7 @@
             if (this.onRotate !== undefined && typeof this.onRotate === 'function') {
                 this.onRotate.bind(this)();
             }
-            
+
             this.lastAppliedAngle = this._angle;
 
         }
@@ -308,7 +308,7 @@
 
     p.initOptions = function (options) {
         options = options || defaults;
-        
+
         this.touchElement = document.querySelectorAll(options.touchElement)[0] || this.element;
 
         this.onRotate = options.onRotate || options.onrotate;


### PR DESCRIPTION
...as a simple attempt to sort of support multitouch.

Currently if we have multiple Propeller instances on the same page [(much like the example page)](http://pixelscommander.com/polygon/propeller/example/jquerygrid.html), only one touch would be registered for the whole page, because [only the first touches of the `event.touches` is ever used in the calculation of the movement of the elements](https://github.com/PixelsCommander/Propeller/blob/55accc3c443641505ab38fd458f32f13718517fc/src/propeller.js#L175-L180).

This update changes the reference from `event.touches` to `event.targetTouches`. Instead of using the first of all touches registered in the webpage, it uses the first of the touches on the target. [With reference to the MDN page](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/targetTouches), it is:

> A TouchList listing all the Touch objects for touch points that are still in contact with the touch surface and whose touchstart event occurred inside the same target element as the current target element.

Be noted that multiple touches on the *same* Propeller element is still absent in this update. It only concerns the cases where multiple touches on *different* Propeller elements.

I am not aware of any side-effects as of now. But I would be happy to see if it is useful to any library users out there for this too. Please advise on this patch. Thanks!