### PR TITLE
correct npm package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ JavaScript library to rotate elements by mouse. Supports inertia and stepwise ro
 ##Usage
 
 ####Available on NPM
-    npm install propeller
+    npm install Propeller
 
 ####Easy-to-use as jQuery plugin:
     $(nodeOrSelector).propeller(options);


### PR DESCRIPTION
There is already another package in the npm registry with the name "propeller". Took me quite a bit to figure out, that the readme points to the wrong package name "npm install propeller" instead of "npm install Propeller".
